### PR TITLE
remove redundant NoInlining hacks in regex and xml

### DIFF
--- a/src/Argon.Xml/XmlNodeConverter.cs
+++ b/src/Argon.Xml/XmlNodeConverter.cs
@@ -1215,26 +1215,7 @@ public class XmlNodeConverter : JsonConverter
     /// <returns>
     /// <c>true</c> if this instance can convert the specified value type; otherwise, <c>false</c>.
     /// </returns>
-    public override bool CanConvert(Type valueType)
-    {
-        if (valueType.AssignableToTypeName("System.Xml.Linq.XObject", false))
-        {
-            return IsXObject(valueType);
-        }
-
-        if (valueType.AssignableToTypeName("System.Xml.XmlNode", false))
-        {
-            return IsXmlNode(valueType);
-        }
-
-        return false;
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool IsXObject(Type valueType) =>
-        typeof(XObject).IsAssignableFrom(valueType);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool IsXmlNode(Type valueType) =>
+    public override bool CanConvert(Type valueType) =>
+        typeof(XObject).IsAssignableFrom(valueType) ||
         typeof(XmlNode).IsAssignableFrom(valueType);
 }

--- a/src/Argon.Xml/XmlTypeExtensions.cs
+++ b/src/Argon.Xml/XmlTypeExtensions.cs
@@ -34,7 +34,4 @@ static class XmlTypeExtensions
         match = null;
         return false;
     }
-
-    public static bool AssignableToTypeName(this Type type, string fullTypeName, bool searchInterfaces) =>
-        type.AssignableToTypeName(fullTypeName, searchInterfaces, out _);
 }

--- a/src/Argon/Converters/RegexConverter.cs
+++ b/src/Argon/Converters/RegexConverter.cs
@@ -135,9 +135,5 @@ public class RegexConverter : JsonConverter
     /// 	<c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
     /// </returns>
     public override bool CanConvert(Type type) =>
-        type.Name == nameof(Regex) && IsRegex(type);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    static bool IsRegex(Type type) =>
-        type == typeof(Regex);
+        type.FullName == "System.Text.RegularExpressions.Regex";
 }


### PR DESCRIPTION
 * fully qualify System.Text.RegularExpressions.Regex
 * XML impl already in another assembly. so no need to avoid loading the xml assemblies