### PR TITLE
Add a new Argon.FSharp.Tests project + add tests for the FSharpListConverter + fix the converter

### DIFF
--- a/src/Argon.FSharp.Tests/Argon.FSharp.Tests.fsproj
+++ b/src/Argon.FSharp.Tests/Argon.FSharp.Tests.fsproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="FSharpListConverterTests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xunit" Version="2.4.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Argon.FSharp\Argon.FSharp.csproj" />
+    <ProjectReference Include="..\ArgonTests\ArgonTests.csproj" />
+    <ProjectReference Include="..\Argon\Argon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Argon.FSharp.Tests/FSharpListConverterTests.fs
+++ b/src/Argon.FSharp.Tests/FSharpListConverterTests.fs
@@ -1,0 +1,130 @@
+module FSharpListConverterTests
+
+open System
+open Argon
+open Xunit
+
+[<Fact>]
+let ``Serialize List of int`` () =
+    let input = [ 1; 2; 3 ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  1,
+  2,
+  3
+]""",
+        json)
+
+type MyClass(prop) =
+    member val Prop = prop with get, set
+    new() = MyClass(0)
+
+[<Fact>]
+let ``Serialize List of class`` () =
+    let input = [ MyClass(1); MyClass(2) ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  {
+    "Prop": 1
+  },
+  {
+    "Prop": 2
+  }
+]""",
+        json)
+
+type MyRecord = { RecordProp: int }
+
+[<Fact>]
+let ``Serialize List of records`` () =
+    let input = [ { RecordProp = 1 }; { RecordProp = 2 } ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  {
+    "RecordProp": 1
+  },
+  {
+    "RecordProp": 2
+  }
+]""",
+        json)
+
+[<Fact>]
+let ``Serialize List of anonymous records`` () =
+    let input = [ {| AnonymousRecordProp = 1 |}; {| AnonymousRecordProp = 2 |} ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  {
+    "AnonymousRecordProp": 1
+  },
+  {
+    "AnonymousRecordProp": 2
+  }
+]""",
+        json)
+
+type MyDU =
+    | Case1
+    | Case2 of int
+    | Case3 of asdf: int
+
+[<Fact>]
+let ``Serialize List of DU cases`` () =
+    let input = [ MyDU.Case1; MyDU.Case2(1); MyDU.Case3(42) ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        // Without the DU converter, nothing is serialized
+        // since DU cases are compiled to fields that are ignored by default:
+        """[
+  {},
+  {},
+  {}
+]""",
+        json)
+
+[<Fact>]
+let ``Serialize List of DU cases with explicit DU converter`` () =
+    let input = [ MyDU.Case1; MyDU.Case2(1); MyDU.Case3(42) ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter(), DiscriminatedUnionConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  {
+    "Case": "Case1"
+  },
+  {
+    "Case": "Case2",
+    "Fields": [
+      1
+    ]
+  },
+  {
+    "Case": "Case3",
+    "Fields": [
+      42
+    ]
+  }
+]""",
+        json)
+
+[<Fact>]
+let ``Serialize List of tuples`` () =
+    let input = [ (1,2,3); (4,5,6) ]
+    let json = JsonConvert.SerializeObject(input, Formatting.Indented, FSharpListConverter())
+    XUnitAssert.AreEqualNormalized(
+        """[
+  {
+    "Item1": 1,
+    "Item2": 2,
+    "Item3": 3
+  },
+  {
+    "Item1": 4,
+    "Item2": 5,
+    "Item3": 6
+  }
+]""",
+        json)

--- a/src/Argon.FSharp.Tests/Program.fs
+++ b/src/Argon.FSharp.Tests/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/src/Argon.FSharp/FSharpListConverter.cs
+++ b/src/Argon.FSharp/FSharpListConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Argon;
+namespace Argon;
 
 // ReSharper disable UnusedMember.Global
 /// <summary>
@@ -13,7 +13,7 @@ public class FSharpListConverter : JsonConverter
         writer.WriteStartArray();
         foreach (var item in (IEnumerable)value)
         {
-            writer.WriteValue(item);
+            serializer.Serialize(writer, item);
         }
         writer.WriteEndArray();
     }

--- a/src/Argon.sln
+++ b/src/Argon.sln
@@ -6,9 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B520C700-7D45-4D82-BFB5-218FA68CF5CF}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		appveyor.yml = appveyor.yml
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
-		appveyor.yml = appveyor.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Argon", "Argon\Argon.csproj", "{A97A4CB3-51AD-4605-BA9F-D6861E582C85}"
@@ -23,9 +23,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Argon.DataSets", "Argon.Dat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Argon.JsonPath", "Argon.JsonPath\Argon.JsonPath.csproj", "{5705E5CF-E410-4510-AB3C-4FCC4E4BC991}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Argon.NodaTime", "Argon.NodaTime\Argon.NodaTime.csproj", "{63A6C5B9-CE2A-4117-AA05-B8EC7A6AA521}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Argon.NodaTime", "Argon.NodaTime\Argon.NodaTime.csproj", "{63A6C5B9-CE2A-4117-AA05-B8EC7A6AA521}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Argon.FSharp", "Argon.FSharp\Argon.FSharp.csproj", "{5C3567D2-B8AB-4679-8E44-C5862F56E49B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Argon.FSharp", "Argon.FSharp\Argon.FSharp.csproj", "{5C3567D2-B8AB-4679-8E44-C5862F56E49B}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Argon.FSharp.Tests", "Argon.FSharp.Tests\Argon.FSharp.Tests.fsproj", "{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -82,6 +84,12 @@ Global
 		{5C3567D2-B8AB-4679-8E44-C5862F56E49B}.DebugNet7|Any CPU.Build.0 = DebugNet7|Any CPU
 		{5C3567D2-B8AB-4679-8E44-C5862F56E49B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C3567D2-B8AB-4679-8E44-C5862F56E49B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.DebugNet7|Any CPU.ActiveCfg = DebugNet7|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.DebugNet7|Any CPU.Build.0 = DebugNet7|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48D5E2FB-0F62-41D9-A3F6-79E31A13F1D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
It seems the `FSharpListConverter` was no longer working with anything else than primitive values.

I fixed it by replacing `writer.WriteValue(item);` with `serializer.Serialize(writer, item);` but I don't know enough to be certain it's the correct/best fix, so please review :)

I also added an fsharp test project to make sure this does not happen again. I wasn't entirely sure how to call it or where to put it, so I used my best guess.

(I also had a hard time making the solution work with all its targets, so I only targeted net6.0 for this new test project. I think this is a good start)

---

Note: this is related to https://github.com/VerifyTests/Verify/pull/911: it seems an FSharp list is also a discriminated union internally — that's why I was getting a nested list of linked nodes instead of an array when I put the DiscriminatedUnionConverter first in the list of converters. It was actually correct to put it last to avoid this issue.