### PR TITLE
tests: make `dotnet test` run for `Argon.FSharp.Tests`

### DIFF
--- a/src/Argon.FSharp.Tests/Argon.FSharp.Tests.fsproj
+++ b/src/Argon.FSharp.Tests/Argon.FSharp.Tests.fsproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <Compile Include="FSharpListConverterTests.fs" />
-    <Compile Include="Program.fs" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Argon.FSharp.Tests/Program.fs
+++ b/src/Argon.FSharp.Tests/Program.fs
@@ -1,1 +1,0 @@
-module Program = let [<EntryPoint>] main _ = 0


### PR DESCRIPTION
Hello,

While taking a look at Argon.FSharp for suggesting an improvement I discovered that I was not able to run the `dotnet test` against `Argon.FSharp.Tests`.

```text
➜  Argon.FSharp.Tests git:(main) ✗ dotnet test
Restore complete (0.7s)
  Argon net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon/bin/Debug/net9.0/Argon.dll
  Argon.FSharp net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.FSharp/bin/Debug/net9.0/Argon.FSharp.dll
  Argon.Xml net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.Xml/bin/Debug/net9.0/Argon.Xml.dll
  Argon.NodaTime net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.NodaTime/bin/Debug/net9.0/Argon.NodaTime.dll
  Argon.DataSets net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.DataSets/bin/Debug/net9.0/Argon.DataSets.dll
  Argon.JsonPath net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.JsonPath/bin/Debug/net9.0/Argon.JsonPath.dll
  Argon.InterfaceCallbacks net9.0 succeeded (0.1s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.InterfaceCallbacks/bin/Debug/net9.0/Argon.InterfaceCallbacks.dll
  ArgonTests net9.0 succeeded (0.2s) → /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/ArgonTests/bin/Debug/net9.0/ArgonTests.dll
  Argon.FSharp.Tests failed with 1 error(s) (0.5s)
    /Users/mmangel/Workspaces/Github/SimonCropp/Argon/src/Argon.FSharp.Tests/Program.fs(1,1): error FS0222: Files in libraries or multiple-file applications must begin with a namespace or module declaration. When using a module declaration at the start of a file the '=' sign is not allowed. If this is a top-level module, consider removing the = to resolve this error.
```

Because `Argon.FSharp.Tests` is not an executable we can simply remove `Program.fs` and then run `dotnet test` against the project.

![CleanShot 2024-08-26 at 21 54 55](https://github.com/user-attachments/assets/707b7a00-3147-423d-a534-77fe84bd54db)
