### PR TITLE
feat: lower FSharp.Core requirements

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="FSharp.Core" Version="8.0.301" />
+    <PackageVersion Include="FSharp.Core" Version="5.0.2" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="27.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Hello,

This PR is a proposition to lower FSharp.Core, I made a PR instead of an issue because it like that it is easier showcase the impact on the code (basically none 😅).

When authoring F# libraries, it is recommended to make FSharp.Core dependency as low as possible. It allows a library to reach a larger range of codebase.

Otherwise people will get warning like:

> Detected package downgrade: FSharp.Core from 8.0.200 to 8.0.101. Reference the package directly from the project to select a different version. 

`Argon.FSharp` doesn't seems to use any new F# APIs, so it is possible to lower it from `8.0.301` too `5.0.2` or even `4.7.2`. 

You can read more about FSharp.Core management [here](https://fsharp.github.io/fsharp-compiler-docs/fsharp-core-notes.html#Guidance-for-package-authors)

I decided to propose `5.0.2` because based on my experience this works fine.