### PR TITLE
Use ReferenceEquals for escaped unicode check

### DIFF
--- a/src/Argon/Utilities/JavaScriptUtils.cs
+++ b/src/Argon/Utilities/JavaScriptUtils.cs
@@ -206,7 +206,10 @@ static class JavaScriptUtils
                 continue;
             }
 
-            var isEscapedUnicodeText = string.Equals(escapedValue, escapedUnicodeText, StringComparison.Ordinal);
+            // Safe to use ReferenceEquals: escapedValue is either null (handled above),
+            // a string literal from the switch branches, or the escapedUnicodeText sentinel
+            // assigned directly at line 199. No other branch produces a string equal to "!".
+            var isEscapedUnicodeText = ReferenceEquals(escapedValue, escapedUnicodeText);
 
             if (i > lastWritePosition)
             {


### PR DESCRIPTION
Replace string.Equals with ReferenceEquals when testing for the escapedUnicodeText sentinel to avoid unnecessary string comparison and make intent explicit. Add a clarifying comment explaining why ReferenceEquals is safe here (escapedValue is either null, a switch literal, or the sentinel assigned earlier). This improves clarity and can be marginally faster by avoiding content comparison.