### PR TITLE
avoid OrderBy().ToList() in DefaultContractResolver.CreateProperties

### DIFF
--- a/src/Argon/Serialization/DefaultContractResolver.cs
+++ b/src/Argon/Serialization/DefaultContractResolver.cs
@@ -676,7 +676,24 @@ public class DefaultContractResolver : IContractResolver
             properties.AddProperty(property);
         }
 
-        return properties.OrderBy(_ => _.Order ?? -1).ToList();
+        var list = new List<JsonProperty>(properties);
+
+        var needsSort = false;
+        foreach (var property in list)
+        {
+            if (property.Order != null)
+            {
+                needsSort = true;
+                break;
+            }
+        }
+
+        if (needsSort)
+        {
+            list.Sort(static (a, b) => (a.Order ?? -1).CompareTo(b.Order ?? -1));
+        }
+
+        return list;
     }
 
     public virtual JsonNameTable GetNameTable() => nameTable;

--- a/src/ArgonTests/Benchmarks/PropertyOrderBenchmark.cs
+++ b/src/ArgonTests/Benchmarks/PropertyOrderBenchmark.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2007 James Newton-King. All rights reserved.
+// Use of this source code is governed by The MIT License,
+// as found in the license.md file.
+
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser]
+public class PropertyOrderBenchmark
+{
+    JsonPropertyCollection properties = null!;
+
+    [Params(5, 20, 100)]
+    public int Count { get; set; }
+
+    [Params(false, true)]
+    public bool AnyOrder { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        properties = new(typeof(object));
+        for (var i = 0; i < Count; i++)
+        {
+            var property = new JsonProperty(typeof(string), typeof(object))
+            {
+                PropertyName = "P" + i
+            };
+            if (AnyOrder && i % 3 == 0)
+            {
+                property.Order = Count - i;
+            }
+
+            properties.AddProperty(property);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public IList<JsonProperty> OrderByToList() =>
+        properties.OrderBy(_ => _.Order ?? -1).ToList();
+
+    [Benchmark]
+    public IList<JsonProperty> InPlaceSort()
+    {
+        var list = new List<JsonProperty>(properties);
+
+        var needsSort = false;
+        foreach (var property in list)
+        {
+            if (property.Order != null)
+            {
+                needsSort = true;
+                break;
+            }
+        }
+
+        if (needsSort)
+        {
+            list.Sort(static (a, b) => (a.Order ?? -1).CompareTo(b.Order ?? -1));
+        }
+
+        return list;
+    }
+}

--- a/src/Benchmark.Tests/Program.cs
+++ b/src/Benchmark.Tests/Program.cs
@@ -11,7 +11,7 @@ public class Program
         var attribute = (AssemblyFileVersionAttribute)typeof(JsonConvert).Assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute))!;
         Console.WriteLine($"Json.NET Version: {attribute.Version}");
 
-        var switcher = new BenchmarkSwitcher([typeof(WriteEscapedJavaScriptString), typeof(SerializeJTokenList), typeof(ReadQuotedNumbers), typeof(WriteBase64Benchmark)]);
+        var switcher = new BenchmarkSwitcher([typeof(WriteEscapedJavaScriptString), typeof(SerializeJTokenList), typeof(ReadQuotedNumbers), typeof(WriteBase64Benchmark), typeof(PropertyOrderBenchmark)]);
         if (args.Length == 0)
         {
             switcher.Run(["*"]);


### PR DESCRIPTION
  Replace the LINQ ordering with an in-place List<T>.Sort, and skip
  sorting entirely when no property has an explicit Order. The previous
  path allocated an OrderedEnumerable, a key-selector delegate, and an
  intermediate buffer for every contract built.

  Benchmark (net10.0, PropertyOrderBenchmark):

    Count=5,   no order:  319 ns / 464 B  ->   63 ns /  96 B  (0.20x time, 0.21x alloc)
    Count=20,  no order:  710 ns / 816 B  ->  106 ns / 216 B  (0.15x time, 0.26x alloc)
    Count=100, no order: 4009 ns / 2736 B ->  388 ns / 856 B  (0.10x time, 0.31x alloc)
    Count=100, mixed:    6201 ns / 2736 B -> 5570 ns / 856 B  (0.90x time, 0.31x alloc)