### PR TITLE
avoid Keys/Values ToList materialization in DictionaryWrapper

### DIFF
--- a/src/Argon/Utilities/DictionaryWrapper.cs
+++ b/src/Argon/Utilities/DictionaryWrapper.cs
@@ -10,6 +10,63 @@ interface IWrappedDictionary
     object UnderlyingDictionary { get; }
 }
 
+sealed class ReadOnlyCollectionWrapper<T>(IEnumerable<T> source, int count)
+    : ICollection<T>, ICollection
+{
+    public int Count => count;
+
+    public bool IsReadOnly => true;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => this;
+
+    public IEnumerator<T> GetEnumerator() =>
+        source.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        source.GetEnumerator();
+
+    public bool Contains(T item)
+    {
+        var comparer = EqualityComparer<T>.Default;
+        foreach (var x in source)
+        {
+            if (comparer.Equals(x, item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        foreach (var x in source)
+        {
+            array[arrayIndex++] = x;
+        }
+    }
+
+    void ICollection.CopyTo(Array array, int index)
+    {
+        foreach (var x in source)
+        {
+            array.SetValue(x, index++);
+        }
+    }
+
+    public void Add(T item) =>
+        throw new NotSupportedException();
+
+    public void Clear() =>
+        throw new NotSupportedException();
+
+    public bool Remove(T item) =>
+        throw new NotSupportedException();
+}
+
 class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>, IWrappedDictionary
 {
     readonly IDictionary dictionary;
@@ -65,12 +122,12 @@ class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>, IWrappedDicti
         {
             if (dictionary != null)
             {
-                return dictionary.Keys.Cast<TKey>().ToList();
+                return new ReadOnlyCollectionWrapper<TKey>(dictionary.Keys.Cast<TKey>(), dictionary.Count);
             }
 
             if (readOnlyDictionary != null)
             {
-                return readOnlyDictionary.Keys.ToList();
+                return new ReadOnlyCollectionWrapper<TKey>(readOnlyDictionary.Keys, readOnlyDictionary.Count);
             }
 
             return genericDictionary.Keys;
@@ -126,12 +183,12 @@ class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>, IWrappedDicti
         {
             if (dictionary != null)
             {
-                return dictionary.Values.Cast<TValue>().ToList();
+                return new ReadOnlyCollectionWrapper<TValue>(dictionary.Values.Cast<TValue>(), dictionary.Count);
             }
 
             if (readOnlyDictionary != null)
             {
-                return readOnlyDictionary.Values.ToList();
+                return new ReadOnlyCollectionWrapper<TValue>(readOnlyDictionary.Values, readOnlyDictionary.Count);
             }
 
             return genericDictionary.Values;
@@ -458,12 +515,12 @@ class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>, IWrappedDicti
         {
             if (genericDictionary != null)
             {
-                return genericDictionary.Keys.ToList();
+                return new ReadOnlyCollectionWrapper<TKey>(genericDictionary.Keys, genericDictionary.Count);
             }
 
             if (readOnlyDictionary != null)
             {
-                return readOnlyDictionary.Keys.ToList();
+                return new ReadOnlyCollectionWrapper<TKey>(readOnlyDictionary.Keys, readOnlyDictionary.Count);
             }
 
             return dictionary!.Keys;
@@ -492,12 +549,12 @@ class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>, IWrappedDicti
         {
             if (genericDictionary != null)
             {
-                return genericDictionary.Values.ToList();
+                return new ReadOnlyCollectionWrapper<TValue>(genericDictionary.Values, genericDictionary.Count);
             }
 
             if (readOnlyDictionary != null)
             {
-                return readOnlyDictionary.Values.ToList();
+                return new ReadOnlyCollectionWrapper<TValue>(readOnlyDictionary.Values, readOnlyDictionary.Count);
             }
 
             return dictionary!.Values;

--- a/src/ArgonTests/Benchmarks/DictionaryWrapperKeysBenchmark.cs
+++ b/src/ArgonTests/Benchmarks/DictionaryWrapperKeysBenchmark.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2007 James Newton-King. All rights reserved.
+// Use of this source code is governed by The MIT License,
+// as found in the license.md file.
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser]
+public class DictionaryWrapperKeysBenchmark
+{
+    Hashtable hashtable = null!;
+    Dictionary<string, int> dictionary = null!;
+    ReadOnlyDictionary<string, int> readOnlyDictionary = null!;
+    DictionaryWrapper<string, int> wrapperHashtable = null!;
+    DictionaryWrapper<string, int> wrapperReadOnly = null!;
+    DictionaryWrapper<string, int> wrapperGeneric = null!;
+
+    [Params(5, 50, 500)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        hashtable = [];
+        dictionary = new();
+        for (var i = 0; i < Count; i++)
+        {
+            var key = "K" + i;
+            hashtable[key] = i;
+            dictionary[key] = i;
+        }
+
+        readOnlyDictionary = new(dictionary);
+        wrapperHashtable = new((IDictionary) hashtable);
+        wrapperReadOnly = new((IReadOnlyDictionary<string, int>) readOnlyDictionary);
+        wrapperGeneric = new((IDictionary<string, int>) dictionary);
+    }
+
+    // IDictionary-backed (Hashtable): old materializes List<string> via Cast+ToList; new returns wrapper
+
+    [Benchmark(Baseline = true)]
+    public ICollection<string> Hashtable_Old() =>
+        hashtable.Keys.Cast<string>().ToList();
+
+    [Benchmark]
+    public ICollection<string> Hashtable_New() =>
+        wrapperHashtable.Keys;
+
+    [Benchmark]
+    public int Hashtable_Old_Iterate()
+    {
+        var total = 0;
+        foreach (var key in hashtable.Keys.Cast<string>().ToList())
+        {
+            total += key.Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int Hashtable_New_Iterate()
+    {
+        var total = 0;
+        foreach (var key in wrapperHashtable.Keys)
+        {
+            total += key.Length;
+        }
+
+        return total;
+    }
+
+    // IReadOnlyDictionary-backed: old materializes List<string>; new returns wrapper
+
+    [Benchmark]
+    public ICollection<string> ReadOnly_Old() =>
+        readOnlyDictionary.Keys.ToList();
+
+    [Benchmark]
+    public ICollection<string> ReadOnly_New() =>
+        wrapperReadOnly.Keys;
+
+    // IDictionary<,>.Keys surfaced via non-generic IDictionary.Keys: old ToList'd into ICollection; new returns wrapper
+
+    [Benchmark]
+    public ICollection Generic_Old_NonGeneric() =>
+        dictionary.Keys.ToList();
+
+    [Benchmark]
+    public ICollection Generic_New_NonGeneric() =>
+        ((IDictionary) wrapperGeneric).Keys;
+}

--- a/src/Benchmark.Tests/Program.cs
+++ b/src/Benchmark.Tests/Program.cs
@@ -11,7 +11,7 @@ public class Program
         var attribute = (AssemblyFileVersionAttribute)typeof(JsonConvert).Assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute))!;
         Console.WriteLine($"Json.NET Version: {attribute.Version}");
 
-        var switcher = new BenchmarkSwitcher([typeof(WriteEscapedJavaScriptString), typeof(SerializeJTokenList), typeof(CamelCaseBenchmarks), typeof(ReadQuotedNumbers), typeof(WriteBase64Benchmark), typeof(SplitFullyQualifiedTypeNameBench), typeof(PropertyOrderBenchmark)]);
+        var switcher = new BenchmarkSwitcher([typeof(WriteEscapedJavaScriptString), typeof(SerializeJTokenList), typeof(CamelCaseBenchmarks), typeof(ReadQuotedNumbers), typeof(WriteBase64Benchmark), typeof(SplitFullyQualifiedTypeNameBench), typeof(PropertyOrderBenchmark), typeof(DictionaryWrapperKeysBenchmark)]);
         if (args.Length == 0)
         {
             switcher.Run(["*"]);


### PR DESCRIPTION
  The Keys/Values properties (both the generic ICollection<T> and the
  non-generic IDictionary surface) materialized a full List<T> on every
  access via Cast<T>().ToList() / ToList(). Replace with a lazy
  ReadOnlyCollectionWrapper<T> that holds the source IEnumerable<T> plus
  a snapshot Count and defers enumeration to the caller.

  Benchmark (net11.0 in-process, DictionaryWrapperKeysBenchmark):

    Access only (no iteration):
      Hashtable.Keys      Count=500: 16,541 ns / 4160 B ->  43 ns /  80 B
      ReadOnly.Keys       Count=500:  4,060 ns / 4056 B ->  33 ns /  32 B
      IDictionary.Keys    Count=500:  3,735 ns / 4056 B ->  19 ns /  32 B

    Access + foreach:
      Hashtable.Keys      Count=500: 17,530 ns / 4160 B -> 16,443 ns / 136 B
      Hashtable.Keys      Count=5  :    228 ns /  200 B ->    198 ns / 136 B

  Allocations drop from O(N) to a flat 32-80 B regardless of dictionary
  size. CPU is dominated by the underlying Cast iterator on the iterate
  path, so wall-time wins there are modest; the pure-access path (e.g.
  reflection / introspection callers that never enumerate) is 100-400x
  faster at Count=500.